### PR TITLE
Fix MainWindow control references

### DIFF
--- a/src/TetrisPro.App/Views/MainWindow.xaml
+++ b/src/TetrisPro.App/Views/MainWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="TetrisPro.App.Views.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="TetrisPro.App.Controls" 
+        xmlns:controls="clr-namespace:TetrisPro.App.Controls"
         Title="TetrisPro" Height="700" Width="520"
         Background="{DynamicResource Brush.Background}">
     <Grid Margin="16">
@@ -10,16 +10,15 @@
             <ColumnDefinition Width="220" />
         </Grid.ColumnDefinitions>
 
-
-        <controls: Grid.Column="0"
+        <controls:PlayfieldControl Grid.Column="0"
                                    ItemsSource="{Binding BoardCells}" />
 
-        <StackPanel Grid.Column="1" Margin="16,0,0,0" VerticalAlignment="Top" Spacing="12">
+        <StackPanel Grid.Column="1" Margin="16,0,0,0" VerticalAlignment="Top">
             <TextBlock Text="NEXT" Foreground="{DynamicResource Brush.Foreground}" FontWeight="Bold" />
-            <controls:MiniBoardControl ItemsSource="{Binding NextPieces}" />
+            <controls:MiniBoardControl ItemsSource="{Binding NextPieces}" Margin="0,12,0,0" />
 
             <TextBlock Text="HOLD" Margin="0,16,0,0" Foreground="{DynamicResource Brush.Foreground}" FontWeight="Bold" />
-            <controls:MiniBoardControl ItemsSource="{Binding HoldPiece}" />
+            <controls:MiniBoardControl ItemsSource="{Binding HoldPiece}" Margin="0,12,0,0" />
 
             <StackPanel Margin="0,16,0,0">
                 <TextBlock Text="{Binding Score, StringFormat=Score: {0}}"
@@ -32,9 +31,9 @@
                            Foreground="{DynamicResource Brush.Foreground}" />
             </StackPanel>
 
-            <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,12,0,0">
-                <Button Content="New Game" Command="{Binding NewGameCommand}" />
-                <Button Content="Pause" Command="{Binding PauseCommand}" />
+            <StackPanel Orientation="Horizontal" Margin="0,12,0,0">
+                <Button Content="New Game" Command="{Binding NewGameCommand}" Margin="0,0,8,0" />
+                <Button Content="Pause" Command="{Binding PauseCommand}" Margin="0,0,8,0" />
                 <Button Content="Resume" Command="{Binding ResumeCommand}" />
             </StackPanel>
         </StackPanel>

--- a/src/TetrisPro.App/Views/MainWindow.xaml.cs
+++ b/src/TetrisPro.App/Views/MainWindow.xaml.cs
@@ -17,13 +17,10 @@ public partial class MainWindow : Window
     public MainWindow(IInputService input, RenderTicker ticker, IGameEngine engine, MainViewModel vm)
     {
         InitializeComponent();
-        // Через DI (если App держит ServiceProvider)
-        var vm = ((App)Application.Current).Services.GetRequiredService<MainViewModel>();
         DataContext = vm;
 
-        // Если DI ещё не поднят — временный fallback:
         // DataContext = new MainViewModel();
-         _input = input;
+        _input = input;
         _ticker = ticker;
         _engine = engine;
         _ticker.Tick += OnTick;


### PR DESCRIPTION
## Summary
- Correct control namespace and XAML usage in MainWindow
- Remove unsupported StackPanel spacing and use margins
- Initialize MainWindow DataContext using injected ViewModel

## Testing
- `dotnet build TetrisPro.sln -p:EnableWindowsTargeting=true` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ef5dcd4c8332ba94e835ea5f1023