### PR TITLE
Fix Playfield control namespace resolution

### DIFF
--- a/src/TetrisPro.App/Views/MainWindow.xaml
+++ b/src/TetrisPro.App/Views/MainWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="TetrisPro.App.Views.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:TetrisPro.App.Controls"
+        xmlns:controls="clr-namespace:TetrisPro.App.Controls;assembly=TetrisPro.App"
         Title="TetrisPro" Height="700" Width="520"
         Background="{DynamicResource Brush.Background}">
     <Grid Margin="16">


### PR DESCRIPTION
## Summary
- specify control assembly in MainWindow namespace declaration so PlayfieldControl resolves

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f0c2e3e48332aff058141efeba0a