### PR TITLE
Add UpdateState stub and fix control namespace

### DIFF
--- a/src/TetrisPro.App/ViewModels/MainViewModel.cs
+++ b/src/TetrisPro.App/ViewModels/MainViewModel.cs
@@ -89,7 +89,7 @@ namespace TetrisPro.App.ViewModels
 
         public MainViewModel()
         {
-            // демо-заливка поля
+            // РґРµРјРѕ-Р·Р°Р»РёРІРєР° РїРѕР»СЏ
             for (int i = 0; i < 200; i++)
             {
                 BoardCells.Add(new CellVm
@@ -103,6 +103,16 @@ namespace TetrisPro.App.ViewModels
         [RelayCommand] private void NewGame() { }
         [RelayCommand] private void Pause() { }
         [RelayCommand] private void Resume() { }
+
+        /// <summary>
+        /// Refreshes the values exposed by the view model.  The current
+        /// implementation is a stub used to satisfy the build and can be
+        /// expanded to pull data from the game engine once it is available.
+        /// </summary>
+        public void UpdateState()
+        {
+            // Intentionally left blank вЂ“ game state updates will be wired in later.
+        }
     }
 
     public class CellVm

--- a/src/TetrisPro.App/Views/MainWindow.xaml
+++ b/src/TetrisPro.App/Views/MainWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="TetrisPro.App.Views.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:TetrisPro.App.Controls;assembly=TetrisPro.App"
+        xmlns:controls="clr-namespace:TetrisPro.App.Controls"
         Title="TetrisPro" Height="700" Width="520"
         Background="{DynamicResource Brush.Background}">
     <Grid Margin="16">


### PR DESCRIPTION
## Summary
- stub out MainViewModel.UpdateState so the view can call it during ticks
- use local namespace for custom controls in MainWindow

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a74da6529c8332bfe85d4b8f634960