### PR TITLE
Add AI autoplay with speed controls

### DIFF
--- a/src/TetrisPro.App/App.xaml.cs
+++ b/src/TetrisPro.App/App.xaml.cs
@@ -23,6 +23,7 @@ public partial class App : Application
                 services.AddSingleton<ITimeProvider, SystemTimeProvider>();
                 services.AddSingleton<IGameEngine, GameEngine>();
                 services.AddSingleton<RenderTicker>();
+                services.AddSingleton<AutoPlayer>();
                 services.AddSingleton<MainViewModel>();
                 services.AddTransient<Views.MainWindow>();
             })

--- a/src/TetrisPro.App/Services/AutoPlayer.cs
+++ b/src/TetrisPro.App/Services/AutoPlayer.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TetrisPro.Core.Engine;
+using TetrisPro.Core.Models;
+using TetrisPro.Core.Services;
+
+namespace TetrisPro.App.Services;
+
+/// <summary>
+/// Simple AI player that finds a good placement for the active piece and
+/// simulates key presses on the <see cref="IInputService"/>.
+/// </summary>
+public class AutoPlayer
+{
+    private readonly IGameEngine _engine;
+    private readonly IInputService _input;
+
+    private Tetromino? _lastPiece;
+    private readonly Queue<InputKey> _actions = new();
+    private readonly HashSet<InputKey> _release = new();
+    private bool _softDrop;
+
+    public bool Enabled { get; set; }
+    public int SpeedMultiplier { get; private set; } = 1;
+
+    public AutoPlayer(IGameEngine engine, IInputService input)
+    {
+        _engine = engine;
+        _input = input;
+    }
+
+    /// <summary>Cycles speed multiplier: 1x → 2x → 4x → 8x → 1x.</summary>
+    public void CycleSpeed()
+    {
+        SpeedMultiplier = SpeedMultiplier switch { 1 => 2, 2 => 4, 4 => 8, _ => 1 };
+    }
+
+    public void ResetSpeed() => SpeedMultiplier = 1;
+
+    public void Update()
+    {
+        // Release keys from previous frame.
+        foreach (var k in _release.ToList())
+        {
+            _input.KeyUp(k);
+            _release.Remove(k);
+        }
+
+        if (!Enabled)
+        {
+            ReleaseAll();
+            return;
+        }
+
+        var piece = _engine.State.ActivePiece;
+        if (piece != _lastPiece)
+        {
+            _lastPiece = piece;
+            _actions.Clear();
+            _softDrop = false;
+            if (piece != null)
+            {
+                var plan = FindBestPlacement(_engine.State.Board, piece.Clone());
+                EnqueueMoves(piece, plan.targetX, plan.targetRot);
+            }
+        }
+
+        if (_actions.Count > 0)
+        {
+            var key = _actions.Dequeue();
+            _input.KeyDown(key);
+            _release.Add(key);
+        }
+        else if (!_softDrop)
+        {
+            _input.KeyDown(InputKey.SoftDrop);
+            _softDrop = true;
+        }
+    }
+
+    private void ReleaseAll()
+    {
+        if (_softDrop)
+        {
+            _input.KeyUp(InputKey.SoftDrop);
+            _softDrop = false;
+        }
+        foreach (var k in _release.ToList())
+        {
+            _input.KeyUp(k);
+            _release.Remove(k);
+        }
+        _actions.Clear();
+        _lastPiece = null;
+    }
+
+    private void EnqueueMoves(Tetromino current, int targetX, Rotation targetRot)
+    {
+        // Rotation moves
+        int diff = ((int)targetRot - (int)current.Rotation + 4) & 3;
+        switch (diff)
+        {
+            case 1: _actions.Enqueue(InputKey.RotateCW); break;
+            case 2: _actions.Enqueue(InputKey.Rotate180); break;
+            case 3: _actions.Enqueue(InputKey.RotateCCW); break;
+        }
+
+        // Horizontal moves
+        int dx = targetX - current.Position.X;
+        if (dx < 0)
+            for (int i = 0; i < -dx; i++) _actions.Enqueue(InputKey.Left);
+        else if (dx > 0)
+            for (int i = 0; i < dx; i++) _actions.Enqueue(InputKey.Right);
+    }
+
+    private (int targetX, Rotation targetRot) FindBestPlacement(Board board, Tetromino piece)
+    {
+        double bestScore = double.NegativeInfinity;
+        int bestX = piece.Position.X;
+        Rotation bestRot = piece.Rotation;
+
+        foreach (Rotation rot in Enum.GetValues(typeof(Rotation)))
+        {
+            var p = piece.Clone();
+            p.Rotation = rot;
+            // Adjust starting Y so that piece is fully inside board.
+            int minY = p.Cells.Min(c => c.Y);
+            p.Position = new PointI(p.Position.X, -minY);
+
+            int minX = -p.Cells.Min(c => c.X);
+            int maxX = Board.Width - 1 - p.Cells.Max(c => c.X);
+            for (int x = minX; x <= maxX; x++)
+            {
+                p.Position = new PointI(x, p.Position.Y);
+                var b = CloneBoard(board);
+                // Drop piece
+                while (!b.IsCollision(p))
+                    p.Position += new PointI(0, 1);
+                p.Position -= new PointI(0, 1);
+
+                foreach (var c in p.Cells)
+                {
+                    var pos = c + p.Position;
+                    b[pos.X, pos.Y] = p.Type;
+                }
+                int lines = b.ClearFullLines();
+                double score = Evaluate(b, lines);
+                if (score > bestScore)
+                {
+                    bestScore = score;
+                    bestX = x;
+                    bestRot = rot;
+                }
+            }
+        }
+        return (bestX, bestRot);
+    }
+
+    private static Board CloneBoard(Board source)
+    {
+        var b = new Board();
+        for (int x = 0; x < Board.Width; x++)
+            for (int y = 0; y < Board.TotalHeight; y++)
+                b[x, y] = source[x, y];
+        return b;
+    }
+
+    private static double Evaluate(Board board, int lines)
+    {
+        int[] heights = new int[Board.Width];
+        int holes = 0;
+        for (int x = 0; x < Board.Width; x++)
+        {
+            bool block = false;
+            for (int y = 0; y < Board.TotalHeight; y++)
+            {
+                if (board[x, y].HasValue)
+                {
+                    if (!block)
+                    {
+                        heights[x] = Board.TotalHeight - y;
+                        block = true;
+                    }
+                }
+                else if (block)
+                {
+                    holes++;
+                }
+            }
+        }
+
+        int aggregateHeight = heights.Sum();
+        int bumpiness = 0;
+        for (int x = 0; x < Board.Width - 1; x++)
+            bumpiness += Math.Abs(heights[x] - heights[x + 1]);
+
+        return 0.76 * lines - 0.18 * aggregateHeight - 0.51 * holes - 0.36 * bumpiness;
+    }
+}
+

--- a/src/TetrisPro.App/ViewModels/MainViewModel.cs
+++ b/src/TetrisPro.App/ViewModels/MainViewModel.cs
@@ -7,6 +7,7 @@ using System.Windows.Media;
 using TetrisPro.Core.Config;
 using TetrisPro.Core.Engine;
 using TetrisPro.Core.Models;
+using TetrisPro.App.Services;
 
 namespace TetrisPro.App.ViewModels;
 
@@ -18,6 +19,7 @@ namespace TetrisPro.App.ViewModels;
 public partial class MainViewModel : ObservableObject
 {
     private readonly IGameEngine _engine;
+    private readonly AutoPlayer _ai;
 
     /// <summary>Cells representing the playfield (10×20).</summary>
     public ObservableCollection<CellVm> BoardCells { get; } = new();
@@ -30,10 +32,14 @@ public partial class MainViewModel : ObservableObject
     [ObservableProperty] private int level;
     [ObservableProperty] private int lines;
     [ObservableProperty] private string statusText = "Ready";
+    [ObservableProperty] private bool aiEnabled;
+    [ObservableProperty] private string aiText = "AI Off";
+    [ObservableProperty] private string speedText = "1x";
 
-    public MainViewModel(IGameEngine engine)
+    public MainViewModel(IGameEngine engine, AutoPlayer ai)
     {
         _engine = engine;
+        _ai = ai;
 
         // Initialise board with empty cells so bindings are ready before the
         // first update occurs.
@@ -56,6 +62,22 @@ public partial class MainViewModel : ObservableObject
 
     [RelayCommand] private void Pause() => _engine.Pause();
     [RelayCommand] private void Resume() => _engine.Resume();
+    [RelayCommand]
+    private void ToggleAi()
+    {
+        AiEnabled = !AiEnabled;
+        _ai.Enabled = AiEnabled;
+        _ai.ResetSpeed();
+        AiText = AiEnabled ? "AI On" : "AI Off";
+        SpeedText = "1x";
+    }
+
+    [RelayCommand]
+    private void CycleSpeed()
+    {
+        _ai.CycleSpeed();
+        SpeedText = $"{_ai.SpeedMultiplier}x";
+    }
 
     /// <summary>
     /// Refreshes all values exposed by the view model from the engine's state.

--- a/src/TetrisPro.App/Views/MainWindow.xaml
+++ b/src/TetrisPro.App/Views/MainWindow.xaml
@@ -36,6 +36,10 @@
                 <Button Content="Pause" Command="{Binding PauseCommand}" Margin="0,0,8,0" />
                 <Button Content="Resume" Command="{Binding ResumeCommand}" />
             </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                <Button Content="{Binding AiText}" Command="{Binding ToggleAiCommand}" Margin="0,0,8,0" />
+                <Button Content="{Binding SpeedText}" Command="{Binding CycleSpeedCommand}" IsEnabled="{Binding AiEnabled}" />
+            </StackPanel>
         </StackPanel>
     </Grid>
 </Window>

--- a/src/TetrisPro.App/Views/MainWindow.xaml.cs
+++ b/src/TetrisPro.App/Views/MainWindow.xaml.cs
@@ -14,8 +14,9 @@ public partial class MainWindow : Window
     private readonly IInputService _input;
     private readonly RenderTicker _ticker;
     private readonly IGameEngine _engine;
+    private readonly AutoPlayer _ai;
 
-    public MainWindow(IInputService input, RenderTicker ticker, IGameEngine engine, MainViewModel vm)
+    public MainWindow(IInputService input, RenderTicker ticker, IGameEngine engine, AutoPlayer ai, MainViewModel vm)
     {
         InitializeComponent();
         DataContext = vm;
@@ -24,6 +25,7 @@ public partial class MainWindow : Window
         _input = input;
         _ticker = ticker;
         _engine = engine;
+        _ai = ai;
         _ticker.Tick += OnTick;
         _ticker.Start();
         KeyDown += OnKeyDownHandler;
@@ -32,6 +34,9 @@ public partial class MainWindow : Window
 
     private void OnTick(object? sender, TimeSpan delta)
     {
+        _ai.Update();
+        if (_ai.Enabled)
+            delta = TimeSpan.FromTicks(delta.Ticks * _ai.SpeedMultiplier);
         _engine.Update(delta);
         if (DataContext is MainViewModel vm)
             vm.UpdateState();


### PR DESCRIPTION
## Summary
- Implement AutoPlayer service that searches for optimal piece placement and simulates input
- Add AI and Speed buttons to toggle autoplay and cycle through 1x/2x/4x/8x speeds
- Wire speed multiplier into update loop and register new service

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b09f89d48332adedeff01565c453