### PR TITLE
Move AutoPlayer to core and improve placement search

### DIFF
--- a/src/TetrisPro.App/App.xaml.cs
+++ b/src/TetrisPro.App/App.xaml.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using TetrisPro.Core.Engine;
 using TetrisPro.Core.Services;
+using TetrisPro.Core.AI;
 using TetrisPro.App.Services;
 using TetrisPro.App.ViewModels;
 

--- a/src/TetrisPro.App/ViewModels/MainViewModel.cs
+++ b/src/TetrisPro.App/ViewModels/MainViewModel.cs
@@ -7,7 +7,7 @@ using System.Windows.Media;
 using TetrisPro.Core.Config;
 using TetrisPro.Core.Engine;
 using TetrisPro.Core.Models;
-using TetrisPro.App.Services;
+using TetrisPro.Core.AI;
 
 namespace TetrisPro.App.ViewModels;
 

--- a/src/TetrisPro.App/Views/MainWindow.xaml.cs
+++ b/src/TetrisPro.App/Views/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.Windows;
 using System.Windows.Input;
 using TetrisPro.Core.Engine;
 using TetrisPro.Core.Services;
+using TetrisPro.Core.AI;
 using TetrisPro.App.ViewModels;
 using TetrisPro.App.Services;
 using TetrisPro.App.Controls;

--- a/src/TetrisPro.Core/AI/AutoPlayer.cs
+++ b/src/TetrisPro.Core/AI/AutoPlayer.cs
@@ -5,7 +5,7 @@ using TetrisPro.Core.Engine;
 using TetrisPro.Core.Models;
 using TetrisPro.Core.Services;
 
-namespace TetrisPro.App.Services;
+namespace TetrisPro.Core.AI;
 
 /// <summary>
 /// Simple AI player that finds a good placement for the active piece and
@@ -126,13 +126,14 @@ public class AutoPlayer
             p.Rotation = rot;
             // Adjust starting Y so that piece is fully inside board.
             int minY = p.Cells.Min(c => c.Y);
-            p.Position = new PointI(p.Position.X, -minY);
+            int startY = -minY;
+            p.Position = new PointI(p.Position.X, startY);
 
             int minX = -p.Cells.Min(c => c.X);
             int maxX = Board.Width - 1 - p.Cells.Max(c => c.X);
             for (int x = minX; x <= maxX; x++)
             {
-                p.Position = new PointI(x, p.Position.Y);
+                p.Position = new PointI(x, startY);
                 var b = CloneBoard(board);
                 // Drop piece
                 while (!b.IsCollision(p))


### PR DESCRIPTION
## Summary
- relocate AutoPlayer AI into the Core project under new AI folder
- restore piece Y position when evaluating moves so AI shifts pieces correctly
- update application wiring to use the core AI service

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b29cc7d4833296ecfd3629750a30