### PR TITLE
Adjust AI tap speed and planning order

### DIFF
--- a/src/TetrisPro.App/Views/MainWindow.xaml.cs
+++ b/src/TetrisPro.App/Views/MainWindow.xaml.cs
@@ -16,11 +16,12 @@ public partial class MainWindow : Window
     private readonly RenderTicker _ticker;
     private readonly IGameEngine _engine;
     private readonly AutoPlayer _ai;
+    private readonly MainViewModel _vm;
 
     public MainWindow(IInputService input, RenderTicker ticker, IGameEngine engine, AutoPlayer ai, MainViewModel vm)
     {
         InitializeComponent();
-        DataContext = vm;
+        DataContext = _vm = vm;
 
         // DataContext = new MainViewModel();
         _input = input;
@@ -35,12 +36,16 @@ public partial class MainWindow : Window
 
     private void OnTick(object? sender, TimeSpan delta)
     {
-        _ai.Update();
-        if (_ai.Enabled)
-            delta = TimeSpan.FromTicks(delta.Ticks * _ai.SpeedMultiplier);
+        if (_ai != null && _ai.Enabled)
+        {
+            int repeats = Math.Max(1, _ai.SpeedMultiplier);
+            for (int i = 0; i < repeats; i++)
+                _ai.Update();
+        }
+
         _engine.Update(delta);
-        if (DataContext is MainViewModel vm)
-            vm.UpdateState();
+
+        _vm.UpdateState();
     }
 
     private void OnKeyDownHandler(object sender, KeyEventArgs e)


### PR DESCRIPTION
## Summary
- decouple AI speed from gravity tick and update view model directly
- rebuild AutoPlayer planning to move→rotate→hard drop and tap multiple times per frame

## Testing
- `dotnet test -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7bb6e1f948332a85296abc6637003