### PR TITLE
Improve mini board layout and queue order

### DIFF
--- a/src/TetrisPro.App/Controls/MiniBoardControl.xaml
+++ b/src/TetrisPro.App/Controls/MiniBoardControl.xaml
@@ -6,16 +6,16 @@
         <ItemsControl ItemsSource="{Binding ElementName=Root, Path=ItemsSource}">
             <ItemsControl.ItemsPanel>
                 <ItemsPanelTemplate>
-                    <StackPanel Orientation="Vertical"/>
+                    <StackPanel Orientation="Vertical" />
                 </ItemsPanelTemplate>
             </ItemsControl.ItemsPanel>
 
             <ItemsControl.ItemTemplate>
                 <DataTemplate>
-                    <ItemsControl ItemsSource="{Binding}">
+                    <ItemsControl ItemsSource="{Binding}" Width="48" Height="48" HorizontalAlignment="Left">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
-                                <UniformGrid Columns="4" Rows="4"/>
+                                <UniformGrid Columns="4" Rows="4" />
                             </ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>
@@ -24,7 +24,7 @@
                                         Background="{Binding Fill}"
                                         BorderBrush="{Binding Stroke}"
                                         BorderThickness="0.5"
-                                        CornerRadius="2"/>
+                                        CornerRadius="2" />
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>

--- a/src/TetrisPro.App/ViewModels/MainViewModel.cs
+++ b/src/TetrisPro.App/ViewModels/MainViewModel.cs
@@ -100,7 +100,7 @@ public partial class MainViewModel : ObservableObject
 
         // Update next queue.
         NextPieces.Clear();
-        foreach (var type in state.NextQueue)
+        foreach (var type in state.NextQueue.Reverse())
         {
             var piece = new Tetromino(type, ColorFor(type));
             NextPieces.Add(CreateMiniBoard(piece));


### PR DESCRIPTION
## Summary
- Limit mini board size to 4×4 cells so preview pieces display without large gaps
- Render upcoming piece queue from top to bottom for more intuitive stacking

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9166519488332a3bfd966460c5d91