### PR TITLE
Fix AI input handling and restore speed controls

### DIFF
--- a/src/TetrisPro.App/Views/MainWindow.xaml.cs
+++ b/src/TetrisPro.App/Views/MainWindow.xaml.cs
@@ -37,11 +37,7 @@ public partial class MainWindow : Window
     private void OnTick(object? sender, TimeSpan delta)
     {
         if (_ai != null && _ai.Enabled)
-        {
-            int repeats = Math.Max(1, _ai.SpeedMultiplier);
-            for (int i = 0; i < repeats; i++)
-                _ai.Update();
-        }
+            _ai.Update();
 
         _engine.Update(delta);
 

--- a/src/TetrisPro.Core/AI/AutoPlayer.cs
+++ b/src/TetrisPro.Core/AI/AutoPlayer.cs
@@ -47,6 +47,12 @@ public class AutoPlayer
 
     public void Update()
     {
+        // Release keys pressed in the previous frame so that the engine
+        // can observe the current tick's key presses.
+        foreach (var k in _keysToRelease)
+            _input.KeyUp(k);
+        _keysToRelease.Clear();
+
         var piece = _engine.State.ActivePiece;
         if (piece != _lastPiece)
         {
@@ -64,10 +70,6 @@ public class AutoPlayer
             _input.KeyDown(key);
             _keysToRelease.Add(key);
         }
-
-        foreach (var k in _keysToRelease)
-            _input.KeyUp(k);
-        _keysToRelease.Clear();
     }
 
     public List<InputKey> FindBestMoves(Board board, Tetromino current)


### PR DESCRIPTION
## Summary
- prevent AI from releasing keys before the engine processes them
- simplify tick loop so AI speed button affects key taps correctly

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a919c9b2d4833281dacc4d603123f4