### PR TITLE
Make vertical cell spacing uniform with horizontal

### DIFF
--- a/src/TetrisPro.App/Controls/MiniBoardControl.xaml
+++ b/src/TetrisPro.App/Controls/MiniBoardControl.xaml
@@ -20,7 +20,7 @@
                         </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <Border Width="12" Height="12" Margin="0.5"
+                                <Border Width="12" Height="12" Margin="0.5,0.25"
                                         Background="{Binding Fill}"
                                         BorderBrush="{Binding Stroke}"
                                         BorderThickness="0.5"

--- a/src/TetrisPro.App/Controls/PlayfieldControl.xaml
+++ b/src/TetrisPro.App/Controls/PlayfieldControl.xaml
@@ -12,7 +12,7 @@
 
             <ItemsControl.ItemTemplate>
                 <DataTemplate>
-                    <Border Width="24" Height="24" Margin="0.5"
+                    <Border Width="24" Height="24" Margin="0.5,0.25"
                             Background="{Binding Fill}"
                             BorderBrush="{Binding Stroke}"
                             BorderThickness="0.5"


### PR DESCRIPTION
## Summary
- Tighten vertical spacing in playfield so gaps match horizontal spacing
- Apply same vertical spacing adjustment to mini boards for consistency

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a9bf6ffe448332aedbccdfaaf73599